### PR TITLE
Fix: Error calling blastx in rule Dnaapler

### DIFF
--- a/hybracter/workflow/rules/preflight/functions.smk
+++ b/hybracter/workflow/rules/preflight/functions.smk
@@ -125,3 +125,11 @@ def check_db(database_dir):
             "\n"
         )
         sys.exit(1)
+
+
+## helper function to set dnaapler threads to 1 if rule is retried
+def get_cpu_resources_with_fallback(wildcards, attempt):
+    if attempt == 1:
+        return config['resources']['med']['cpu']
+    else:
+        return 1

--- a/hybracter/workflow/rules/reorientation/dnaapler.smk
+++ b/hybracter/workflow/rules/reorientation/dnaapler.smk
@@ -24,7 +24,8 @@ rule dnaapler:
         mem_mb=config.resources.med.mem,
         mem=str(config.resources.med.mem) + "MB",
         time=config.resources.med.time,
-    threads: config.resources.med.cpu
+    retries: 2
+    threads: get_cpu_resources_with_fallback
     benchmark:
         os.path.join(dir.out.bench, "dnaapler", "{sample}.txt")
     log:

--- a/hybracter/workflow/rules/reorientation/dnaapler_custom.smk
+++ b/hybracter/workflow/rules/reorientation/dnaapler_custom.smk
@@ -24,7 +24,8 @@ rule dnaapler_custom:
         mem_mb=config.resources.med.mem,
         mem=str(config.resources.med.mem) + "MB",
         time=config.resources.med.time,
-    threads: config.resources.med.cpu
+    retries: 2
+    threads: get_cpu_resources_with_fallback
     benchmark:
         os.path.join(dir.out.bench, "dnaapler", "{sample}.txt")
     log:

--- a/hybracter/workflow/rules/reorientation/dnaapler_custom_no_medaka.smk
+++ b/hybracter/workflow/rules/reorientation/dnaapler_custom_no_medaka.smk
@@ -22,7 +22,8 @@ rule dnaapler_custom:
         mem_mb=config.resources.med.mem,
         mem=str(config.resources.med.mem) + "MB",
         time=config.resources.med.time,
-    threads: config.resources.med.cpu
+    retries: 2
+    threads: get_cpu_resources_with_fallback
     benchmark:
         os.path.join(dir.out.bench, "dnaapler", "{sample}.txt")
     log:

--- a/hybracter/workflow/rules/reorientation/dnaapler_no_medaka.smk
+++ b/hybracter/workflow/rules/reorientation/dnaapler_no_medaka.smk
@@ -21,7 +21,8 @@ rule dnaapler_no_medaka:
         mem_mb=config.resources.med.mem,
         mem=str(config.resources.med.mem) + "MB",
         time=config.resources.med.time,
-    threads: config.resources.med.cpu
+    retries: 2
+    threads: get_cpu_resources_with_fallback
     benchmark:
         os.path.join(dir.out.bench, "dnaapler", "{sample}.txt")
     log:


### PR DESCRIPTION
Hi,

this PR attempts to fix #54. 

As discussed [in that issue](https://github.com/gbouras13/hybracter/issues/54#issuecomment-2379351600), the Dnaapler rule might fail, if not enough memory is given. 
However, even if I set the "medium" ressources the same as the "big" ressources in the config file, the Dnaapler rule still failed with the same error for me. The only solution was to run hybracter with `--cores 1`.

In this PR, I use the `retries: ` directive and a small helper function to set the threads for the Dnaapler rules to 1, if the rule fails with the usual `config.resources.med.cpu`.

Let me know if I can improve something.

Best wishes,
Richard 
