### PR TITLE
Freeze versions and add linting of Dockerfile 

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,16 @@
+name: Linting
+
+on:
+  push:
+
+jobs:
+
+  docker-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,35 +2,35 @@
 # hybracter 
 #
 
-FROM staphb/unicycler:0.5.0
+FROM staphb/unicycler:0.5.1
 
 ARG DEBIAN_FRONTEND="noninteractive"
-ARG LIBFABRIC_VERSION=1.18.1
-ARG HYBRACTER_VERSION=0.7.1
+ARG LIBFABRIC_VERSION=2.0.0
+ARG HYBRACTER_VERSION=0.11.2
 ARG MINIFORGE_VERSION=24.11.3-0
 
 # Install required packages and dependencies
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -y update \
     && apt-get -y install --no-install-recommends \
-    build-essential=12.8ubuntu1.1 \
-    autoconf=2.69-11.1  \
-    automake=1:1.16.1-4ubuntu6  \
-    wget=1.20.3-1ubuntu2.1 \
-    doxygen=1.8.17-0ubuntu2  \
-    gnupg=2.2.19-3ubuntu2.2  \
-    gnupg2=2.2.19-3ubuntu2.2  \
-    apt-transport-https=2.0.10  \
-    software-properties-common=0.99.9.12  \
-    git=1:2.25.1-1ubuntu3.13  \
-    vim=2:8.1.2269-1ubuntu5.31  \
-    gfortran=4:9.3.0-1ubuntu2  \
-    libtool=2.4.6-14 \
-    python3-venv=3.8.2-0ubuntu2 \
-    ninja-build=1.10.0-1build1 \
-    python3-pip=20.0.2-5ubuntu1.11  \
-    libnuma-dev=2.0.12-1  \
-    python3-dev=3.8.2-0ubuntu2 \
+    build-essential=12.9ubuntu3 \
+    autoconf=2.71-2 \
+    automake=1:1.16.5-1.3  \
+    wget=1.21.2-2ubuntu1.1 \
+    doxygen=1.9.1-2ubuntu2 \
+    gnupg=2.2.27-3ubuntu2.1 \
+    gnupg2=2.2.27-3ubuntu2.1 \
+    apt-transport-https=2.4.13 \
+    software-properties-common=0.99.22.9 \
+    git=1:2.34.1-1ubuntu1.12 \
+    vim=2:8.2.3995-1ubuntu2.23 \
+    gfortran=4:11.2.0-1ubuntu1 \
+    libtool=2.4.6-15build2 \
+    python3-venv=3.10.6-1~22.04.1 \
+    ninja-build=1.10.1-1 \
+    python3-pip=22.0.2+dfsg-1ubuntu0.5 \
+    libnuma-dev=2.0.14-3ubuntu2 \
+    python3-dev=3.10.6-1~22.04.1 \
     && apt-get -y remove --purge --auto-remove cmake \
     && wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
     | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
@@ -61,7 +61,7 @@ ENV PATH /opt/miniforge3/bin:$PATH
 #
 RUN set -eux ; \
     mamba install -y -c conda-forge -c bioconda -c defaults \
-    hybracter=${HYBRACTER_VERSION}=pyhdfd78af_0 \
+    hybracter=${HYBRACTER_VERSION} \
     && mamba clean -af -y
 ENV PATH /opt/miniforge3/bin:$PATH
 

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,7 +2,6 @@
 # hybracter 
 #
 
-FROM --platform=linux/amd64 ubuntu:20.04
 FROM staphb/unicycler:0.5.0
 
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -65,6 +65,6 @@ RUN set -eux ; \
 ENV PATH /opt/miniforge3/bin:$PATH
 
 RUN hybracter install --medaka \
-    & hybracter test-hybrid --threads 8 \
-    & hybracter test-long --threads 16  --conda-create-envs-only \
-    & rm -rf hybracter_out
+    && hybracter test-hybrid --threads 8 \
+    && hybracter test-long --threads 16  --conda-create-envs-only \
+    && rm -rf hybracter_out

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -63,7 +63,6 @@ RUN set -eux ; \
     mamba install -y -c conda-forge -c bioconda -c defaults \
     hybracter=${HYBRACTER_VERSION} \
     && mamba clean -af -y
-ENV PATH /opt/miniforge3/bin:$PATH
 
 RUN hybracter install --medaka \
     && hybracter test-hybrid --threads 8 \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get -y update \
     && tar xf v${LIBFABRIC_VERSION}.tar.gz
 
 # Build and install libfabric
-WORKDIR /libfabric-${LIBFABRIC_VERSION}
+WORKDIR /data/libfabric-${LIBFABRIC_VERSION}
 RUN ./autogen.sh \
     && ./configure \
     && make -j 16 \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -50,7 +50,7 @@ RUN apt -y update \
 # Install miniforge
 #
 RUN set -eux ; \
-    wget https://github.com/conda-forge/miniforge/releases/${MINIFORGE_VERSION}/download/Miniforge3-Linux-x86_64.sh ; \
+    wget https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh ; \
     bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
     rm -rf ./Miniforge3-*
 ENV PATH /opt/miniforge3/bin:$PATH

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -8,6 +8,7 @@ FROM staphb/unicycler:0.5.0
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG LIBFABRIC_VERSION=1.18.1
 ARG HYBRACTER_VERSION=0.7.1
+ARG MINIFORGE_VERSION=24.11.3-0
 
 # Install required packages and dependencies
 RUN apt -y update \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,3 @@
-
 #
 # hybracter 
 #
@@ -6,54 +5,66 @@
 FROM --platform=linux/amd64 ubuntu:20.04
 FROM staphb/unicycler:0.5.0
 
-ENV DEBIAN_FRONTEND="noninteractive"
-
+ARG DEBIAN_FRONTEND="noninteractive"
 ARG LIBFABRIC_VERSION=1.18.1
+ARG HYBRACTER_VERSION=0.7.1
 
 # Install required packages and dependencies
-RUN   apt -y update \
-      && apt -y install build-essential wget doxygen gnupg gnupg2 curl apt-transport-https software-properties-common  \
- git vim gfortran libtool python3-venv ninja-build python3-pip \
-      libnuma-dev python3-dev \
-      && apt -y remove --purge --auto-remove cmake \
-      && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
- | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
-      && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ jammy-rc main" \
-      && apt -y update 
-
-# Build and install libfabric
-RUN (if [ -e /tmp/build ]; then rm -rf /tmp/build; fi;) \
-      && mkdir -p /tmp/build \
-      && cd /tmp/build \
-      && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
-      && tar xf v${LIBFABRIC_VERSION}.tar.gz \
-      && cd libfabric-${LIBFABRIC_VERSION} \ 
-      && ./autogen.sh \
-      && ./configure \
-      && make -j 16 \ 
-      && make install
+RUN apt -y update \
+    && apt -y install build-essential \
+    wget \
+    doxygen \
+    gnupg \
+    gnupg2 \
+    curl \
+    apt-transport-https \
+    software-properties-common  \
+    git \
+    vim \
+    gfortran \
+    libtool \
+    python3-venv \
+    ninja-build \
+    python3-pip \
+    libnuma-dev \
+    python3-dev \
+    && apt -y remove --purge --auto-remove cmake \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
+    | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+    && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ jammy-rc main" \
+    && apt -y update \
+    # Build and install libfabric
+    && rm -rf /tmp/build \
+    && mkdir -p /tmp/build \
+    && cd /tmp/build \
+    && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
+    && tar xf v${LIBFABRIC_VERSION}.tar.gz \
+    && cd libfabric-${LIBFABRIC_VERSION} \
+    && ./autogen.sh \
+    && ./configure \
+    && make -j 16 \
+    && make install \
+    && rm -rf /var/lib/apt/lists/*
 
 #
 # Install miniforge
 #
 RUN set -eux ; \
-  curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh ; \
-  bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
-  rm -rf ./Miniforge3-*
+    curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh ; \
+    bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
+    rm -rf ./Miniforge3-*
 ENV PATH /opt/miniforge3/bin:$PATH
+
 #
 # Install conda environment
 # 
-ARG HYBRACTER_VERSION=0.7.1
 RUN set -eux ; \
-  mamba install -y -c conda-forge -c bioconda -c defaults \
-  hybracter=${HYBRACTER_VERSION}=pyhdfd78af_0  
+    mamba install -y -c conda-forge -c bioconda -c defaults \
+    hybracter=${HYBRACTER_VERSION}=pyhdfd78af_0 \
+    && mamba clean -af -y
 ENV PATH /opt/miniforge3/bin:$PATH
-RUN conda clean -af -y
 
-RUN hybracter install --medaka 
-RUN hybracter test-hybrid --threads 8 
-RUN hybracter test-long --threads 16  --conda-create-envs-only 
-RUN rm -rf hybracter_out
-
-
+RUN hybracter install --medaka \
+    & hybracter test-hybrid --threads 8 \
+    & hybracter test-long --threads 16  --conda-create-envs-only \
+    & rm -rf hybracter_out

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get -y update \
     && tar xf v${LIBFABRIC_VERSION}.tar.gz
 
 # Build and install libfabric
-WORKDIR libfabric-${LIBFABRIC_VERSION}
+WORKDIR /libfabric-${LIBFABRIC_VERSION}
 RUN ./autogen.sh \
     && ./configure \
     && make -j 16 \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -32,18 +32,16 @@ RUN apt-get -y update \
     | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
     && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ jammy-rc main" \
     && apt-get -y update \
-    # Build and install libfabric
-    && rm -rf /tmp/build \
-    && mkdir -p /tmp/build \
-    && cd /tmp/build \
+    && rm -rf /var/lib/apt/lists/* \
     && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
-    && tar xf v${LIBFABRIC_VERSION}.tar.gz \
-    && cd libfabric-${LIBFABRIC_VERSION} \
-    && ./autogen.sh \
+    && tar xf v${LIBFABRIC_VERSION}.tar.gz
+
+# Build and install libfabric
+WORKDIR libfabric-${LIBFABRIC_VERSION}
+RUN ./autogen.sh \
     && ./configure \
     && make -j 16 \
     && make install \
-    && rm -rf /var/lib/apt/lists/*
 
 #
 # Install miniforge

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -67,5 +67,5 @@ ENV PATH /opt/miniforge3/bin:$PATH
 
 RUN hybracter install --medaka \
     && hybracter test-hybrid --threads 8 \
-    && hybracter test-long --threads 16  --conda-create-envs-only \
+    && hybracter test-long --threads 16 --conda-create-envs-only \
     && rm -rf hybracter_out

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -11,7 +11,8 @@ ARG MINIFORGE_VERSION=24.11.3-0
 
 # Install required packages and dependencies
 RUN apt-get -y update \
-    && apt-get -y install build-essential \
+    && apt-get -y install --no-install-recommends \
+    build-essential=12.8ubuntu1.1 \
     wget=1.20.3-1ubuntu2.1 \
     doxygen=1.8.17-0ubuntu2  \
     gnupg=2.2.19-3ubuntu2.2  \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -13,21 +13,21 @@ ARG MINIFORGE_VERSION=24.11.3-0
 # Install required packages and dependencies
 RUN apt -y update \
     && apt -y install build-essential \
-    wget \
-    doxygen \
-    gnupg \
-    gnupg2 \
-    apt-transport-https \
-    software-properties-common  \
-    git \
-    vim \
-    gfortran \
-    libtool \
-    python3-venv \
-    ninja-build \
-    python3-pip \
-    libnuma-dev \
-    python3-dev \
+    wget=1.20.3-1ubuntu2.1 \
+    doxygen=1.8.17-0ubuntu2  \
+    gnupg=2.2.19-3ubuntu2.2  \
+    gnupg2=2.2.19-3ubuntu2.2  \
+    apt-transport-https=2.0.10  \
+    software-properties-common=0.99.9.12  \
+    git=1:2.25.1-1ubuntu3.13  \
+    vim=2:8.1.2269-1ubuntu5.31  \
+    gfortran=4:9.3.0-1ubuntu2  \
+    libtool=2.4.6-14 \
+    python3-venv=3.8.2-0ubuntu2 \
+    ninja-build=1.10.0-1build1 \
+    python3-pip=20.0.2-5ubuntu1.11  \
+    libnuma-dev=2.0.12-1  \
+    python3-dev=3.8.2-0ubuntu2 \
     && apt -y remove --purge --auto-remove cmake \
     && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
     | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -28,12 +28,12 @@ RUN apt-get -y update \
     libnuma-dev=2.0.12-1  \
     python3-dev=3.8.2-0ubuntu2 \
     && apt-get -y remove --purge --auto-remove cmake \
-    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
+    && wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
     | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
     && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ jammy-rc main" \
     && apt-get -y update \
     && rm -rf /var/lib/apt/lists/* \
-    && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
+    && wget -q https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
     && tar xf v${LIBFABRIC_VERSION}.tar.gz
 
 # Build and install libfabric
@@ -47,7 +47,7 @@ RUN ./autogen.sh \
 # Install miniforge
 #
 RUN set -eux ; \
-    wget https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh ; \
+    wget -q https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-x86_64.sh ; \
     bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
     rm -rf ./Miniforge3-*
 ENV PATH /opt/miniforge3/bin:$PATH

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -16,7 +16,6 @@ RUN apt -y update \
     doxygen \
     gnupg \
     gnupg2 \
-    curl \
     apt-transport-https \
     software-properties-common  \
     git \
@@ -50,7 +49,7 @@ RUN apt -y update \
 # Install miniforge
 #
 RUN set -eux ; \
-    curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh ; \
+    wget https://github.com/conda-forge/miniforge/releases/${MINIFORGE_VERSION}/download/Miniforge3-Linux-x86_64.sh ; \
     bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
     rm -rf ./Miniforge3-*
 ENV PATH /opt/miniforge3/bin:$PATH

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -13,6 +13,8 @@ ARG MINIFORGE_VERSION=24.11.3-0
 RUN apt-get -y update \
     && apt-get -y install --no-install-recommends \
     build-essential=12.8ubuntu1.1 \
+    autoconf=2.69-11.1  \
+    automake=1:1.16.1-4ubuntu6  \
     wget=1.20.3-1ubuntu2.1 \
     doxygen=1.8.17-0ubuntu2  \
     gnupg=2.2.19-3ubuntu2.2  \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,8 +10,8 @@ ARG HYBRACTER_VERSION=0.7.1
 ARG MINIFORGE_VERSION=24.11.3-0
 
 # Install required packages and dependencies
-RUN apt -y update \
-    && apt -y install build-essential \
+RUN apt-get -y update \
+    && apt-get -y install build-essential \
     wget=1.20.3-1ubuntu2.1 \
     doxygen=1.8.17-0ubuntu2  \
     gnupg=2.2.19-3ubuntu2.2  \
@@ -27,11 +27,11 @@ RUN apt -y update \
     python3-pip=20.0.2-5ubuntu1.11  \
     libnuma-dev=2.0.12-1  \
     python3-dev=3.8.2-0ubuntu2 \
-    && apt -y remove --purge --auto-remove cmake \
+    && apt-get -y remove --purge --auto-remove cmake \
     && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
     | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
     && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ jammy-rc main" \
-    && apt -y update \
+    && apt-get -y update \
     # Build and install libfabric
     && rm -rf /tmp/build \
     && mkdir -p /tmp/build \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -10,6 +10,7 @@ ARG HYBRACTER_VERSION=0.7.1
 ARG MINIFORGE_VERSION=24.11.3-0
 
 # Install required packages and dependencies
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get -y update \
     && apt-get -y install --no-install-recommends \
     build-essential=12.8ubuntu1.1 \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /data/libfabric-${LIBFABRIC_VERSION}
 RUN ./autogen.sh \
     && ./configure \
     && make -j 16 \
-    && make install \
+    && make install
 
 #
 # Install miniforge
@@ -55,7 +55,7 @@ ENV PATH /opt/miniforge3/bin:$PATH
 
 #
 # Install conda environment
-# 
+#
 RUN set -eux ; \
     mamba install -y -c conda-forge -c bioconda -c defaults \
     hybracter=${HYBRACTER_VERSION}=pyhdfd78af_0 \


### PR DESCRIPTION
Hello, 

I work as a bioinformatician at a hospital and we would like to adopt hybracter in one of our pipelines. But to do this we require frozen versions for packages in Dockerfiles. I have therefore frozen the versions and updated all the packages to the newest versions. I have also added the docker linter hadolint to the workflow and appeased it by combining some of the layers etc. (hopefully this will also decrease image size). 

I have been unable to run the `hybracter install --medaka` command (also with the original Dockerfile from the main hybracter repo) when building as I get the following error:

``` shell
372.2 [Wed Mar  5 09:42:26 2025]                                                                                                      
372.2 localrule all:                                                                                                                  
372.2     input: /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/plsdb_2023_11_03_v2.msh, /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/plsdb_2023_11_03_v2.tsv, /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/cleanup.flag, /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/medaka.flag  372.2     jobid: 0                                                                                                               
372.2     reason: Input files updated by another job: /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/plsdb_2023_11_03_v2.msh, /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/medaka.flag, /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/cleanup.flag, /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/plsdb_2023_11_03_v2.tsv
372.2     resources: tmpdir=/tmp
372.2
372.2 Waiting at most 5 seconds for missing files:
372.2 /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/medaka.flag (missing locally)                      
377.2 WorkflowError in rule all in file /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/install.smk, line 33:         
377.2 OSError: Missing files after 5 seconds. This might be due to filesystem latency. If that is the case, consider to increase the wait time with --latency-wait:
377.2 /opt/miniforge3/lib/python3.12/site-packages/hybracter/workflow/../databases/medaka.flag (missing locally, parent dir contents: cleanup.flag, plsdb_2023_11_03_v2.msh, plsdb_2023_11_03_v2.tsv, ._plsdb_2023_11_03_v2.msh, ._plsdb_2023_11_03_v2.tsv)                 377.3 [2025:03:05 09:42:31] ERROR: Snakemake failed
------
Dockerfile:67                                                                                                                         --------------------                                                                                                                    66 |
  67 | >>> RUN hybracter install --medaka \                                                                                             68 | >>>     && hybracter test-hybrid --threads 8 \
  69 | >>>     && hybracter test-long --threads 16 --conda-create-envs-only \                                                           70 | >>>     && rm -rf hybracter_out                                                                                                  71 |
--------------------                                                                                                                  ERROR: failed to solve: process "/bin/bash -o pipefail -c hybracter install --medaka     && hybracter test-hybrid --threads 8     && hybracter test-long --threads 16 --conda-create-envs-only     && rm -rf hybracter_out" did not complete successfully: exit code: 1 
```

Maybe you have some hints? We are working from behind a proxy, so that might be the issue(?). Including the proxy in the environment when building (` --build-arg http_proxy=$http_proxy --build-arg https_proxy=$http_proxy --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$http_proxy`) unfortunately does not seem to work. 

**Edit**: My colleague @marrip made me aware of this medaka issue regarding downloading of models behind company proxies, so the proxy seems to be the problem https://github.com/nanoporetech/medaka/issues/414  