### PR TITLE
[Draft] New command: "hybracter automatic" - hybrid and long samples in one go!

### DIFF
--- a/hybracter/__main__.py
+++ b/hybracter/__main__.py
@@ -230,6 +230,9 @@ def print_splash():
 |_| |_|\__, |_.__/|_|  \__,_|\___|\__\___|_|   
        |___/
 
+
+MODIFIED MODIFIED MODIFIED MODIFIED MODIFIED MODIFIED MODIFIED MODIFIED
+!!!!!!!!!!RICHARD, DONT USE THIS IN PRODUCTION!!!!!!!!
 """
     )
 
@@ -357,6 +360,119 @@ Available targets:
     all             Run everything (default)
     print_targets   List available targets
 """
+
+help_msg_automatic = """
+\b
+CLUSTER EXECUTION:
+hybracter automatic ... --profile [profile]
+For information on Snakemake profiles see:
+https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
+\b
+RUN EXAMPLES:
+Required:           hybracter automatic --input [csv file]
+Specify output directory:    hybracter automatic ... --output [directory]
+Specify threads:    hybracter automatic ... --threads [threads]
+Disable conda:      hybracter automatic ... --no-use-conda 
+Change defaults:    hybracter automatic ... --snake-default="-k --nolock"
+Add Snakemake args: hybracter automatic ... --dry-run --keep-going --touch
+Specify targets:    hybracter automatic ... all print_targets
+Available targets:
+    all             Run everything (default)
+    print_targets   List available targets
+"""
+
+@click.command(
+    epilog=help_msg_automatic,
+    context_settings=dict(
+        help_option_names=["-h", "--help"], ignore_unknown_options=True
+    ),
+)
+@click.option("-i", "--input", "_input", help="Input csv file with mixed sample types", type=str, required=True)
+@click.option("--datadir", "datadir", help="Directory/ies where FASTQs are. Can specify 1 directory (long and short FASTQs in same directory) or 2 (separated by comma)", type=str, default=None)
+@click.option(
+    "--no_pypolca",
+    help="Do not use pypolca to polish assemblies with short reads",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+            "--logic",
+            "logic",
+            help="Hybracter logic to select best assembly. Use --last to pick the last polishing round. Use --best to pick best assembly based on ALE (hybrid). ",
+            show_default=True,
+            default="last",
+            type=click.Choice(
+                [
+                    "best",
+                    "last",
+                ]
+            ),
+        )
+@common_options
+def automatic(
+    _input,
+    datadir,
+    no_medaka,
+    auto,
+    no_pypolca,
+    skip_qc,
+    medakaModel,
+    databases,
+    subsample_depth,
+    min_depth,
+    min_quality,
+    flyeModel,
+    min_length,
+    output,
+    contaminants,
+    dnaapler_custom_db,
+    logic,
+    depth_filter,
+    mac,
+    medaka_override,
+    extra_params_flye,
+    log,
+    configfile,
+    **kwargs
+):
+    """Run hybracter in automatic mode - detects sample type from input CSV"""
+    
+    merge_config = {
+        "args": {
+            "input": _input,
+            "datadir": datadir,
+            "output": output,
+            "log": log,
+            "min_length": min_length,
+            "databases": databases,
+            "subsample_depth": subsample_depth,
+            "min_depth":min_depth,
+            "min_quality": min_quality,
+            "no_pypolca": no_pypolca,
+            "skip_qc": skip_qc,
+            "medakaModel": medakaModel,
+            "flyeModel": flyeModel,
+            "contaminants": contaminants,
+            "dnaapler_custom_db": dnaapler_custom_db,
+            "no_medaka": no_medaka,
+            "auto": auto,
+            "mac": mac,
+            "medaka_override": medaka_override,
+            "extra_params_flye": extra_params_flye,
+            "depth_filter": depth_filter,
+            "single": False,
+            "logic": logic,
+            "configfile": configfile
+        }
+    }
+
+    run_snakemake(
+        snakefile_path=snake_base(os.path.join("workflow", "automatic.smk")),
+        configfile=configfile,
+        merge_config=merge_config,
+        log=log,
+        **kwargs
+    )
 
 """
 hybrid
@@ -1083,6 +1199,7 @@ cli.add_command(test_long)
 cli.add_command(config)
 cli.add_command(citation)
 cli.add_command(version)
+cli.add_command(automatic) 
 
 
 def main():

--- a/hybracter/test_data/test_hybrid_automatic_auto.csv
+++ b/hybracter/test_data/test_hybrid_automatic_auto.csv
@@ -1,0 +1,4 @@
+Sample1,hybracter/test_data/Fastqs/test_long_reads.fastq.gz,hybracter/test_data/Fastqs/test_short_reads_R1.fastq.gz,hybracter/test_data/Fastqs/test_short_reads_R2.fastq.gz
+Sample2,hybracter/test_data/Fastqs/test_long_reads_subsampled.fastq.gz,hybracter/test_data/Fastqs/test_short_reads_R1.fastq.gz,hybracter/test_data/Fastqs/test_short_reads_R2.fastq.gz
+Sample3,hybracter/test_data/Fastqs/test_long_reads.fastq.gz,,
+Sample4,hybracter/test_data/Fastqs/test_long_reads_subsampled.fastq.gz,,

--- a/hybracter/workflow/hybrid.smk
+++ b/hybracter/workflow/hybrid.smk
@@ -120,6 +120,7 @@ if config.args.single is False:
         INPUT, False, SUBSAMPLE_DEPTH, DATADIR, MIN_DEPTH, AUTO
     )  # long flag false
     SAMPLES = list(dictReads.keys())
+    HYBRID_SAMPLES = SAMPLES
 # for hybracter hybrid-single
 else:
     dictReads = {}
@@ -131,6 +132,7 @@ else:
     dictReads[config.args.sample]["R1"] = config.args.short_one
     dictReads[config.args.sample]["R2"] = config.args.short_two
     SAMPLES = [config.args.sample]
+    HYBRID_SAMPLES = SAMPLES
 
 
 ##############################

--- a/hybracter/workflow/rules/assembly/plassembler_automatic.smk
+++ b/hybracter/workflow/rules/assembly/plassembler_automatic.smk
@@ -1,0 +1,185 @@
+rule plassembler_long:
+    """
+    runs plassembler for long
+    """
+    wildcard_constraints:
+        sample="|".join(LONG_SAMPLES)  # Only allow hybrid samples
+    input:
+        lrge=os.path.join(
+            dir.out.chrom_size, "{sample}_lrge_estimated_chromosome_size.txt"
+        ),
+        l=os.path.join(dir.out.qc, "{sample}_filt_trim.fastq.gz"),
+    output:
+        fasta=os.path.join(
+            dir.out.plassembler, "{sample}", "plassembler_plasmids.fasta"
+        ),
+        summary=os.path.join(dir.out.plassembler, "{sample}", "plassembler_summary.tsv"),
+        version=os.path.join(dir.out.versions, "{sample}", "plassembler.version"),
+    params:
+        db=dir.plassemblerdb,
+        chromlen=lambda wildcards: str(
+            getMinChromLength(
+                lrge_path=os.path.join(
+                    dir.out.chrom_size,
+                    f"{wildcards.sample}_lrge_estimated_chromosome_size.txt",
+                ),
+                sample=wildcards.sample,
+                auto=AUTO,
+            )
+        ),
+        outdir=os.path.join(dir.out.plassembler, "{sample}"),
+        flye_dir=os.path.join(dir.out.assemblies, "{sample}"),
+        depth_filter=DEPTH_FILTER,
+    conda:
+        os.path.join(dir.env, "plassembler.yaml")
+    resources:
+        mem_mb=config.resources.big.mem,
+        mem=str(config.resources.big.mem) + "MB",
+        time=config.resources.med.time,
+    threads: config.resources.big.cpu
+    benchmark:
+        os.path.join(dir.out.bench, "plassembler_long", "{sample}.txt")
+    log:
+        os.path.join(dir.out.stderr, "plassembler_long", "{sample}.log"),
+    shell:
+        """
+        plassembler long -l {input.l} -o {params.outdir} -d {params.db} -t {threads} -c {params.chromlen} --skip_qc --flye_directory {params.flye_dir} --depth_filter {params.depth_filter} -f 2> {log}
+        touch {output.fasta}
+        touch {output.summary}
+        plassembler --version > {output.version}
+
+        """
+
+rule plassembler_hybrid:
+    """
+    runs plassembler for hybrid
+    need the if statement due to unicycler conda installation being a bit broken.
+    if unicycler --version works, then all good
+    otherwise will install unicycler from pip
+    """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        l=os.path.join(dir.out.qc, "{sample}_filt_trim.fastq.gz"),
+        r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),
+        r2=os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"),
+        lrge=os.path.join(
+            dir.out.chrom_size, "{sample}_lrge_estimated_chromosome_size.txt"
+        ),
+    output:
+        fasta=os.path.join(
+            dir.out.plassembler, "{sample}", "plassembler_plasmids.fasta"
+        ),
+        summary=os.path.join(dir.out.plassembler, "{sample}", "plassembler_summary.tsv"),
+        version=os.path.join(dir.out.versions, "{sample}", "plassembler.version"),
+    params:
+        db=dir.plassemblerdb,
+        chromlen=lambda wildcards: str(
+            getMinChromLength(
+                lrge_path=os.path.join(
+                    dir.out.chrom_size,
+                    f"{wildcards.sample}_lrge_estimated_chromosome_size.txt",
+                ),
+                sample=wildcards.sample,
+                auto=AUTO,
+            )
+        ),
+        outdir=os.path.join(dir.out.plassembler, "{sample}"),
+        flye_dir=os.path.join(dir.out.assemblies, "{sample}"),
+        depth_filter=DEPTH_FILTER,
+    conda:
+        os.path.join(dir.env, "plassembler.yaml")
+    resources:
+        mem_mb=config.resources.big.mem,
+        mem=str(config.resources.big.mem) + "MB",
+        time=config.resources.med.time,
+    threads: config.resources.big.cpu
+    benchmark:
+        os.path.join(dir.out.bench, "plassembler_hybrid", "{sample}.txt")
+    log:
+        os.path.join(dir.out.stderr, "plassembler_hybrid", "{sample}.log"),
+    shell:
+        """
+        plassembler run -l {input.l} -o {params.outdir} -1 {input.r1} -2 {input.r2} -d {params.db} -t {threads} -c {params.chromlen} --skip_qc --flye_directory {params.flye_dir} --depth_filter {params.depth_filter} -f 2> {log}
+        touch {output.fasta}
+        touch {output.summary}
+        plassembler --version > {output.version}
+        """
+
+
+rule add_sample_plassembler_hybrid:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        inp=os.path.join(dir.out.plassembler, "{sample}", "plassembler_summary.tsv"),
+    output:
+        out=os.path.join(
+            dir.out.plassembler_individual_summaries,
+            "{sample}_plassembler_summary.tsv",
+        ),
+    conda:
+        os.path.join(dir.env, "scripts.yaml")
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    script:
+        os.path.join(dir.scripts, "add_sample_plassembler.py")
+
+rule add_sample_plassembler_long:
+    wildcard_constraints:
+        sample="|".join(LONG_SAMPLES)  # Only allow long samples
+    input:
+        inp=os.path.join(dir.out.plassembler, "{sample}", "plassembler_summary.tsv"),
+    output:
+        out=os.path.join(
+            dir.out.plassembler_individual_summaries, "{sample}_with_sample.tsv"
+        ),
+    conda:
+        os.path.join(dir.env, "scripts.yaml")
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    script:
+        os.path.join(dir.scripts, "add_sample_plassembler.py")
+# aggr rule in the aggregate.smk rule - because don't run plassembler on incomplete samples
+
+
+rule plassembler_incomplete_hybrid:
+    """
+    touch the output flag for the plassembler incomplete samples (i.e. don't run plassembler at all)
+    """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    output:
+        flag=os.path.join(dir.out.plassembler_incomplete, "{sample}.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """
+
+rule plassembler_incomplete_long:
+    """
+    touch the output flag for the plassembler incomplete samples (i.e. don't run plassembler at all)
+    """
+    wildcard_constraints:
+        sample="|".join(LONG_SAMPLES)  # Only allow long samples
+    output:
+        flag=os.path.join(dir.out.plassembler_incomplete, "{sample}.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """

--- a/hybracter/workflow/rules/assess/assess_complete_no_medaka.smk
+++ b/hybracter/workflow/rules/assess/assess_complete_no_medaka.smk
@@ -14,6 +14,8 @@ rule assess_chrom_pre_polish:
     """
     Run ALE on Flye chrom after dnaapler & plassembler plasmids
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),
         r2=os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"),
@@ -53,6 +55,8 @@ rule assess_polypolish:
     """
     Run ALE on polypolish
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),
         r2=os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"),
@@ -89,6 +93,8 @@ rule assess_pypolca:
     """
     Run ALE on pypolca
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),
         r2=os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"),

--- a/hybracter/workflow/rules/completeness/aggregate_automatic.smk
+++ b/hybracter/workflow/rules/completeness/aggregate_automatic.smk
@@ -1,0 +1,546 @@
+"""
+
+Stores all the aggregation rules and checkpoints post assembly - due to the split between complete and incomplete
+
+"""
+
+"""
+plassembler
+"""
+
+
+# input function for the rule aggregate
+def aggregate_plassembler_input_hybrid(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[
+        0
+    ].open() as f:
+        if f.read().strip() == "C":
+            return os.path.join(
+                dir.out.plassembler_individual_summaries,
+                "{sample}_plassembler_summary.tsv",
+            )
+        else:  # if incomplete
+            return os.path.join(dir.out.plassembler_incomplete, "{sample}.flag")
+
+
+### from the long_read_polishing
+
+
+rule aggregate_plassembler_input_rule_hybrid:
+    input:
+        aggregate_plassembler_input_hybrid,
+    output:
+        os.path.join(dir.out.aggr_plassembler, "{sample}_hybrid.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        echo {input[0]}
+        touch {output}
+        """
+
+# input function for the rule aggregate
+def aggregate_plassembler_input_long(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[
+        0
+    ].open() as f:
+        if f.read().strip() == "C":
+            return os.path.join(
+                dir.out.plassembler_individual_summaries,
+                "{sample}_plassembler_summary.tsv",
+            )
+        else:  # if incomplete
+            return os.path.join(dir.out.plassembler_incomplete, "{sample}.flag")
+
+
+### from the long_read_polishing
+
+
+rule aggregate_plassembler_input_rule_long:
+    input:
+        aggregate_plassembler_input_long,
+    output:
+        os.path.join(dir.out.aggr_plassembler, "{sample}_long.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        echo {input[0]}
+        touch {output}
+        """
+
+# rule aggr_plassembler_flag_hybrid:
+#     """Aggregate."""
+#     input:
+#         expand(os.path.join(dir.out.aggr_plassembler, "{sample}_hybrid.txt"), sample=HYBRID_SAMPLES),
+#     output:
+#         flag=os.path.join(dir.out.flags, "aggr_plassembler_hybrid.flag"),
+#     resources:
+#         mem_mb=config.resources.sml.mem,
+#         mem=str(config.resources.sml.mem) + "MB",
+#         time=config.resources.sml.time,
+#     threads: config.resources.sml.cpu
+#     shell:
+#         """
+#         touch {output.flag}
+#         """
+
+# rule aggr_plassembler_flag_long:
+#     """Aggregate."""
+#     input:
+#         expand(os.path.join(dir.out.aggr_plassembler, "{sample}_long.txt"), sample=LONG_SAMPLES),
+#     output:
+#         flag=os.path.join(dir.out.flags, "aggr_plassembler_long.flag"),
+#     resources:
+#         mem_mb=config.resources.sml.mem,
+#         mem=str(config.resources.sml.mem) + "MB",
+#         time=config.resources.sml.time,
+#     threads: config.resources.sml.cpu
+#     shell:
+#         """
+#         touch {output.flag}
+#         """
+
+rule aggr_plassembler_flag:
+    """Aggregate."""
+    input:
+        expand(os.path.join(dir.out.aggr_plassembler, "{sample}_long.txt"), sample=LONG_SAMPLES),
+        expand(os.path.join(dir.out.aggr_plassembler, "{sample}_hybrid.txt"), sample=HYBRID_SAMPLES),
+    output:
+        flag=os.path.join(dir.out.flags, "aggr_plassembler.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """
+
+"""
+long read polishing
+"""
+
+
+# input function for the rule aggregate
+def aggregate_long_read_polish_input(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[0].open() as f:
+        if config.args.no_medaka is False:
+            if f.read().strip() == "C":
+                return os.path.join(dir.out.medaka_rd_2, "{sample}", "consensus.fasta")
+            else:  # if incomplete
+                return os.path.join(
+                    dir.out.medaka_incomplete, "{sample}", "consensus.fasta"
+                )
+        else:  # no medaka
+            if f.read().strip() == "C":
+                return os.path.join(
+                    dir.out.dnaapler, "{sample}", "{sample}_reoriented.fasta"
+                )
+            else:  # if incomplete
+                return os.path.join(dir.out.incomp_pre_polish, "{sample}.fasta")
+
+
+### from the long_read_polishing
+
+
+rule aggregate_long_read_polish_input_rule:
+    input:
+        aggregate_long_read_polish_input,
+    output:
+        os.path.join(dir.out.aggr_lr_polish, "{sample}.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        echo {input[0]}
+        touch {output}
+        """
+
+
+rule aggr_long_read_polish_flag:
+    """Aggregate."""
+    input:
+        expand(os.path.join(dir.out.aggr_lr_polish, "{sample}.txt"), sample=SAMPLES),
+    output:
+        flag=os.path.join(dir.out.flags, "aggr_long_read_polish.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """
+
+
+"""
+Short read polishing
+"""
+
+
+# input function for the rule aggregate
+def aggregate_short_read_polish_input(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[0].open() as f:
+        if f.read().strip() == "C":
+            if (
+                config.args.no_pypolca is False
+            ):  # with pypolca - will return this regardless of medaka being run
+                return os.path.join(
+                    dir.out.differences, "{sample}", "pypolca_vs_polypolish.txt"
+                )
+            else:  # no pypolca is true
+                if config.args.no_medaka is False:  # with medaka
+                    return os.path.join(
+                        dir.out.differences, "{sample}", "polypolish_vs_medaka_round_2.txt"
+                    )
+                else:  # no medaka and no pypolca only runs polypolish
+                    return os.path.join(
+                        dir.out.differences, "{sample}", "polypolish_vs_pre_polish.txt"
+                    )
+        else:  # incomplete
+            if (
+                config.args.no_pypolca is False
+            ):  # with pypolca - will return this regardless of medaka being run
+                return os.path.join(
+                    dir.out.pypolca_incomplete, "{sample}", "{sample}_corrected.fasta"
+                )
+            else:  # no pypolca, still will run polypolsh regardless of medaka being run
+                return os.path.join(dir.out.polypolish_incomplete, "{sample}.fasta")
+
+
+### from the short_read_polishing
+
+
+rule aggregate_short_read_polish_input:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        aggregate_short_read_polish_input,
+    output:
+        os.path.join(dir.out.aggr_sr_polish, "{sample}.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output}
+        """
+
+
+rule aggr_short_read_polish_flag:
+    """Aggregate."""
+    input:
+        expand(os.path.join(dir.out.aggr_sr_polish, "{sample}.txt"), sample=HYBRID_SAMPLES),
+    output:
+        flag=os.path.join(dir.out.flags, "aggr_short_read_polish.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """
+
+
+####### polca ##########
+
+"""
+polca
+"""
+
+
+# input function for the rule aggregate polca
+def aggregate_polca_polish_input(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[
+        0
+    ].open() as f:
+        if f.read().strip() == "C":
+            return os.path.join(dir.out.pypolca, "{sample}", "{sample}_corrected.fasta")
+        else:
+            return os.path.join(
+                dir.out.pypolca_incomplete, "{sample}", "{sample}_corrected.fasta"
+            )
+
+
+### from the short_read_polishing
+rule aggregate_polca_polish_input:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        aggregate_polca_polish_input,
+    output:
+        os.path.join(dir.out.aggr_pypolca_polish, "{sample}.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output}
+        """
+
+
+rule aggr_polca_flag:
+    """Aggregate."""
+    input:
+        expand(
+            os.path.join(dir.out.aggr_pypolca_polish, "{sample}.txt"), sample=HYBRID_SAMPLES
+        ),
+    output:
+        flag=os.path.join(dir.out.flags, "aggr_pypolca.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """
+
+
+####### ale ##########
+
+"""
+ale
+
+hybrid
+
+"""
+
+
+# input function for the rule aggregate polca
+def aggregate_ale_input(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[
+        0
+    ].open() as f:
+        if f.read().strip() == "C":  # complete
+            if config.args.no_pypolca is False:  # with pypolca
+                return os.path.join(
+                    dir.out.ale_scores_complete, "{sample}", "pypolca.score"
+                )
+            else:  # with polca, best is polypolish
+                return os.path.join(
+                    dir.out.ale_scores_complete, "{sample}", "polypolish.score"
+                )
+        else:  # incomplete
+            if config.args.no_pypolca is False:  # with pypolca
+                return os.path.join(
+                    dir.out.ale_scores_incomplete,
+                    "{sample}",
+                    "pypolca_incomplete.score",
+                )
+            else:
+                return os.path.join(
+                    dir.out.ale_scores_incomplete,
+                    "{sample}",
+                    "polypolish_incomplete.score",
+                )
+
+
+### from the aggregate_ale_input
+rule aggregate_ale_input_files:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        aggregate_ale_input,
+    output:
+        os.path.join(dir.out.aggr_ale, "{sample}.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output}
+        """
+
+
+rule aggr_ale_flag:
+    """Aggregate."""
+    input:
+        expand(os.path.join(dir.out.aggr_ale, "{sample}.txt"), sample=HYBRID_SAMPLES),
+    output:
+        flag=os.path.join(dir.out.flags, "aggr_ale.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """
+
+
+# input function for aggresgating pyrodigal plassembler analysis
+def aggregate_pyrodigal_plassembler_input(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[
+        0
+    ].open() as f:
+        if f.read().strip() == "C":  # complete
+            return os.path.join(
+                dir.out.plassembler_individual_summaries, "{sample}_with_sample.tsv"
+            )
+        else:
+            return os.path.join(dir.out.plassembler_incomplete, "{sample}.flag")
+
+
+### from the aggregate_pyrodigal_plassembler_input
+rule aggregate_pyrodigal_plassembler_input_rule:
+    input:
+        aggregate_pyrodigal_plassembler_input,
+    output:
+        os.path.join(dir.out.aggr_pyrodigal_plassembler, "{sample}.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output}
+        """
+
+
+rule aggr_pyrodigal_plassembler_flag:
+    """Aggregate."""
+    input:
+        expand(
+            os.path.join(dir.out.aggr_pyrodigal_plassembler, "{sample}.txt"),
+            sample=LONG_SAMPLES,
+        ),
+    output:
+        flag=os.path.join(dir.out.flags, "aggr_pyrodigal_plassembler.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """
+
+"""
+finalise
+
+hybrid
+"""
+
+
+# input function for the rule aggregate polca
+def aggregate_finalised_assemblies(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[0].open() as f:
+        if f.read().strip() == "C":  # complete
+            return os.path.join(dir.out.final_contigs_complete, "{sample}_final.fasta")
+        else:  # incomplete
+            return os.path.join(dir.out.final_contigs_incomplete, "{sample}_final.fasta")
+
+
+### from the aggregate_ale_input
+rule aggregate_finalised_assemblies_rule:
+    input:
+        aggregate_finalised_assemblies,
+    output:
+        os.path.join(dir.out.aggr_final, "{sample}.txt"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output}
+        """
+
+
+"""
+to create the very final summaries
+"""
+
+
+rule create_final_summary:
+    input:
+        expand(os.path.join(dir.out.aggr_final, "{sample}.txt"), sample=SAMPLES),
+    output:
+        hybracter_summary=os.path.join(dir.out.final_summaries, "hybracter_summary.tsv"),
+    params:
+        complete_summaries_dir=dir.out.final_summaries_complete,
+        incomplete_summaries_dir=dir.out.final_summaries_incomplete,
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    conda:
+        os.path.join(dir.env, "scripts.yaml")
+    script:
+        os.path.join(dir.scripts, "create_final_hybracter_summary.py")
+
+
+rule aggr_final_flag:
+    """Aggregate."""
+    input:
+        hybracter_summary=os.path.join(dir.out.final_summaries, "hybracter_summary.tsv"),
+    output:
+        flag=os.path.join(dir.out.flags, "aggr_final.flag"),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    threads: config.resources.sml.cpu
+    shell:
+        """
+        touch {output.flag}
+        """

--- a/hybracter/workflow/rules/finalise/select_best_assembly_automatic_no_medaka.smk
+++ b/hybracter/workflow/rules/finalise/select_best_assembly_automatic_no_medaka.smk
@@ -1,0 +1,328 @@
+"""
+aggregate the ALE scores and pick the best one
+"""
+
+# to import aggregate_ale_input
+
+
+# input function for the rule aggregate polca
+def aggregate_ale_input_finalise(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[
+        0
+    ].open() as f:
+        if f.read().strip() == "C":  # complete
+            if config.args.no_pypolca is False:  # with pypolca
+                return os.path.join(
+                    dir.out.ale_scores_complete, "{sample}", "pypolca.score"
+                )
+            else:  # with polca, best is polypolish
+                return os.path.join(
+                    dir.out.ale_scores_complete, "{sample}", "polypolish.score"
+                )
+        else:  # incomplete
+            if config.args.no_pypolca is False:  # with pypolca
+                return os.path.join(
+                    dir.out.ale_scores_incomplete,
+                    "{sample}",
+                    "pypolca_incomplete.score",
+                )
+            else:
+                return os.path.join(
+                    dir.out.ale_scores_incomplete,
+                    "{sample}",
+                    "polypolish_incomplete.score",
+                )
+
+
+# input function to make sure all comparisons are run
+def aggregate_comparisons(wildcards):
+    # decision based on content of output file
+    # Important: use the method open() of the returned file!
+    # This way, Snakemake is able to automatically download the file if it is generated in
+    # a cloud environment without a shared filesystem.
+    with checkpoints.check_completeness.get(sample=wildcards.sample).output[
+        0
+    ].open() as f:
+        if f.read().strip() == "C":  # complete
+            if config.args.no_pypolca is False:  # with pypolca
+                return os.path.join(
+                    dir.out.differences, "{sample}", "pypolca_vs_polypolish.txt"
+                )
+            else:  # without polca, best is polypolish
+                return os.path.join(
+                    dir.out.differences, "{sample}", "polypolish_vs_pre_polish.txt"
+                )
+        else:  # incomplete
+            if config.args.no_pypolca is False:  # with pypolca
+                return os.path.join(
+                    dir.out.ale_scores_incomplete,
+                    "{sample}",
+                    "pypolca_incomplete.score",
+                )
+            else:
+                return os.path.join(
+                    dir.out.ale_scores_incomplete,
+                    "{sample}",
+                    "polypolish_incomplete.score",
+                )
+
+
+rule dnaapler_pre_chrom:
+    """
+    Runs dnaapler to begin pre polished chromosome 
+    In case it is chosen as best and for comparisons
+    """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        fasta=os.path.join(dir.out.chrom_pre_polish, "{sample}_chromosome.fasta"),
+        ignore_list=os.path.join(dir.out.chrom_pre_polish, "{sample}_ignore_list.txt"),
+    output:
+        fasta=os.path.join(
+            dir.out.dnaapler, "{sample}_pre_chrom", "{sample}_reoriented.fasta"
+        ),
+    conda:
+        os.path.join(dir.env, "dnaapler.yaml")
+    params:
+        dir=os.path.join(dir.out.dnaapler, "{sample}_pre_chrom"),
+    resources:
+        mem_mb=config.resources.med.mem,
+        mem=str(config.resources.med.mem) + "MB",
+        time=config.resources.med.time,
+    threads: config.resources.med.cpu
+    benchmark:
+        os.path.join(dir.out.bench, "dnaapler", "{sample}_pre_chrom.txt")
+    log:
+        os.path.join(dir.out.stderr, "dnaapler", "{sample}_pre_chrom.log"),
+    shell:
+        """
+        dnaapler all -i {input.fasta} -o {params.dir} --ignore {input.ignore_list} -p {wildcards.sample} -t {threads} -a nearest --db dnaa,cog1474,repa -f 2> {log}
+        """
+
+
+### from the aggregate_ale_input function - so it dynamic
+# also calculates the summary
+rule select_best_chromosome_assembly_complete:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        ale_input=aggregate_ale_input_finalise,
+        aggr_ale_flag=os.path.join(dir.out.aggr_ale, "{sample}.txt"),  # to make sure ale has finished
+        plassembler_fasta=os.path.join(
+            dir.out.plassembler, "{sample}", "plassembler_plasmids.fasta"
+        ),
+        flye_info=os.path.join(
+            dir.out.assembly_statistics, "{sample}_assembly_info.txt"
+        ),
+        chrom_pre_polish_fasta=os.path.join(
+            dir.out.dnaapler, "{sample}_pre_chrom", "{sample}_reoriented.fasta"
+        ),
+        comparisons=aggregate_comparisons,
+        ignore_list=os.path.join(dir.out.chrom_pre_polish, "{sample}_ignore_list.txt"),
+    output:
+        chromosome_fasta=os.path.join(
+            dir.out.final_contigs_complete, "{sample}_chromosome.fasta"
+        ),
+        plasmid_fasta=os.path.join(
+            dir.out.final_contigs_complete, "{sample}_plasmid.fasta"
+        ),
+        total_fasta=os.path.join(dir.out.final_contigs_complete, "{sample}_final.fasta"),
+        ale_summary=os.path.join(dir.out.ale_summary, "complete", "{sample}.tsv"),
+        hybracter_summary=os.path.join(
+            dir.out.final_summaries_complete, "{sample}_summary.tsv"
+        ),
+        per_conting_summary=os.path.join(
+            dir.out.final_summaries_complete, "{sample}_per_contig_stats.tsv"
+        ),
+    params:
+        ale_dir=os.path.join(dir.out.ale_scores_complete, "{sample}"),
+        polypolish_fasta=os.path.join(
+            dir.out.intermediate_assemblies, "{sample}", "{sample}_polypolish.fasta"
+        ),
+        polca_fasta=os.path.join(
+            dir.out.intermediate_assemblies, "{sample}", "{sample}_pypolca.fasta"
+        ),
+        logic=LOGIC,
+        no_pypolca=config.args.no_pypolca,
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    conda:
+        os.path.join(dir.env, "scripts.yaml")
+    threads: config.resources.sml.cpu
+    script:
+        os.path.join(
+            dir.scripts_no_medaka, "select_best_chromosome_assembly_complete.py"
+        )
+
+
+### from the aggregate_ale_input function - so it dynamic
+#  also calculates the summary
+rule select_best_chromosome_assembly_incomplete:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
+    input:
+        ale_input=aggregate_ale_input,
+        ale_flag=os.path.join(dir.out.aggr_ale, "{sample}.txt"),  # to make sure ale has finished
+        flye_info=os.path.join(
+            dir.out.assembly_statistics, "{sample}_assembly_info.txt"
+        ),
+    output:
+        fasta=os.path.join(dir.out.final_contigs_incomplete, "{sample}_final.fasta"),
+        ale_summary=os.path.join(dir.out.ale_summary, "incomplete", "{sample}.tsv"),
+        hybracter_summary=os.path.join(
+            dir.out.final_summaries_incomplete, "{sample}_summary.tsv"
+        ),
+        per_conting_summary=os.path.join(
+            dir.out.final_summaries_incomplete, "{sample}_per_contig_stats.tsv"
+        ),
+    params:
+        ale_dir=os.path.join(dir.out.ale_scores_incomplete, "{sample}"),
+        pre_polish_fasta=os.path.join(dir.out.incomp_pre_polish, "{sample}.fasta"),
+        polypolish_fasta=os.path.join(dir.out.polypolish_incomplete, "{sample}.fasta"),
+        polca_fasta=os.path.join(
+            dir.out.pypolca_incomplete, "{sample}", "{sample}_corrected.fasta"
+        ),
+        logic=LOGIC,
+        no_pypolca=config.args.no_pypolca,
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    conda:
+        os.path.join(dir.env, "scripts.yaml")
+    threads: config.resources.sml.cpu
+    script:
+        os.path.join(
+            dir.scripts_no_medaka, "select_best_chromosome_assembly_incomplete.py"
+        )
+
+
+"""
+aggregate the pyrdigal mean length cds and finalise
+"""
+
+
+rule dnaapler_pre_chrom_long:
+    """
+    Runs dnaapler to begin pre polished chromosome 
+    In case it is chosen as best and for comparisons
+    """
+    wildcard_constraints:
+        sample="|".join(LONG_SAMPLES)  # Only allow long samples
+    input:
+        fasta=os.path.join(dir.out.chrom_pre_polish, "{sample}_chromosome.fasta"),
+        ignore_list=os.path.join(dir.out.chrom_pre_polish, "{sample}_ignore_list.txt"),
+    output:
+        fasta=os.path.join(
+            dir.out.dnaapler, "{sample}_pre_chrom", "{sample}_reoriented.fasta"
+        ),
+    conda:
+        os.path.join(dir.env, "dnaapler.yaml")
+    params:
+        dir=os.path.join(dir.out.dnaapler, "{sample}_pre_chrom"),
+    resources:
+        mem_mb=config.resources.med.mem,
+        mem=str(config.resources.med.mem) + "MB",
+        time=config.resources.med.time,
+    threads: config.resources.med.cpu
+    benchmark:
+        os.path.join(dir.out.bench, "dnaapler", "{sample}_pre_chrom.txt")
+    log:
+        os.path.join(dir.out.stderr, "dnaapler", "{sample}_pre_chrom.log"),
+    shell:
+        """
+        dnaapler all -i {input.fasta} -o {params.dir} --ignore {input.ignore_list} -p {wildcards.sample} -t {threads} -a nearest --db dnaa,cog1474,repa -f 2> {log}
+        """
+
+
+### from the aggregate_finalise function - so it dynamic
+rule aggregate_finalise_complete_long:
+    wildcard_constraints:
+        sample="|".join(LONG_SAMPLES)  # Only allow long samples
+    input:
+        chrom_pre_polish_fasta=os.path.join(
+            dir.out.dnaapler, "{sample}_pre_chrom", "{sample}_reoriented.fasta"
+        ),
+        plassembler_plasmid_fasta=os.path.join(
+            dir.out.plassembler, "{sample}", "plassembler_plasmids.fasta"
+        ),
+        flye_info=os.path.join(
+            dir.out.assembly_statistics, "{sample}_assembly_info.txt"
+        ),
+        ignore_list=os.path.join(dir.out.chrom_pre_polish, "{sample}_ignore_list.txt"),
+    output:
+        chromosome_fasta=os.path.join(
+            dir.out.final_contigs_complete, "{sample}_chromosome.fasta"
+        ),
+        plasmid_fasta=os.path.join(
+            dir.out.final_contigs_complete, "{sample}_plasmid.fasta"
+        ),
+        total_fasta=os.path.join(dir.out.final_contigs_complete, "{sample}_final.fasta"),
+        pyrodigal_summary=os.path.join(
+            dir.out.pyrodigal_summary, "complete", "{sample}_summary.tsv"
+        ),
+        hybracter_summary=os.path.join(
+            dir.out.final_summaries_complete, "{sample}_summary.tsv"
+        ),
+        per_conting_summary=os.path.join(
+            dir.out.final_summaries_complete, "{sample}_per_contig_stats.tsv"
+        ),
+    params:
+        complete_flag=True,
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    conda:
+        os.path.join(dir.env, "dnaapler.yaml")  # will contain pyrodigal but dnaapler needed if the best hit is pre-polish (based on Ryan wick's 24-10-23 blogpost medaka might make long only assemblies worse)
+    threads: config.resources.sml.cpu
+    script:
+        os.path.join(
+            dir.scripts_no_medaka, "select_best_chromosome_assembly_long_complete.py"
+        )
+
+
+### from the aggregate_finalise function - so it dynamic
+rule aggregate_finalise_incomplete_long:
+    wildcard_constraints:
+        sample="|".join(LONG_SAMPLES)  # Only allow long samples
+    input:
+        pre_polish_fasta=os.path.join(dir.out.incomp_pre_polish, "{sample}.fasta"),
+        flye_info=os.path.join(
+            dir.out.assembly_statistics, "{sample}_assembly_info.txt"
+        ),
+    output:
+        total_fasta=os.path.join(
+            dir.out.final_contigs_incomplete, "{sample}_final.fasta"
+        ),
+        pyrodigal_summary=os.path.join(
+            dir.out.pyrodigal_summary, "incomplete", "{sample}_summary.tsv"
+        ),
+        hybracter_summary=os.path.join(
+            dir.out.final_summaries_incomplete, "{sample}_summary.tsv"
+        ),
+        per_conting_summary=os.path.join(
+            dir.out.final_summaries_incomplete, "{sample}_per_contig_stats.tsv"
+        ),
+    params:
+        pre_polish_fasta=os.path.join(dir.out.incomp_pre_polish, "{sample}.fasta"),
+        medaka_fasta=os.path.join(
+            dir.out.medaka_incomplete, "{sample}", "consensus.fasta"
+        ),
+    resources:
+        mem_mb=config.resources.sml.mem,
+        mem=str(config.resources.sml.mem) + "MB",
+        time=config.resources.sml.time,
+    conda:
+        os.path.join(dir.env, "pyrodigal.yaml")
+    threads: config.resources.sml.cpu
+    script:
+        os.path.join(
+            dir.scripts_no_medaka, "select_best_chromosome_assembly_long_incomplete.py"
+        )

--- a/hybracter/workflow/rules/polishing/short_read_polish_incomplete.smk
+++ b/hybracter/workflow/rules/polishing/short_read_polish_incomplete.smk
@@ -1,4 +1,6 @@
 rule bwa_index_incomplete:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.medaka_incomplete, "{sample}", "consensus.fasta"),
     output:
@@ -17,6 +19,8 @@ rule bwa_index_incomplete:
 
 
 rule bwa_mem_incomplete:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.medaka_incomplete, "{sample}", "consensus.fasta"),
         r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),
@@ -49,6 +53,8 @@ rule polypolish_incomplete:
     if depth 5-25, run polypolish --careful
     if depth > 25, run polypolish default - might fix errors in repeats pypolca can't
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.medaka_incomplete, "{sample}", "consensus.fasta"),
         sam1=os.path.join(dir.out.bwa_incomplete, "{sample}_1.sam"),

--- a/hybracter/workflow/rules/polishing/short_read_polish_incomplete_no_medaka.smk
+++ b/hybracter/workflow/rules/polishing/short_read_polish_incomplete_no_medaka.smk
@@ -1,4 +1,6 @@
 rule bwa_index_incomplete:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.incomp_pre_polish, "{sample}.fasta"),
     output:
@@ -17,6 +19,8 @@ rule bwa_index_incomplete:
 
 
 rule bwa_mem_incomplete:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.incomp_pre_polish, "{sample}.fasta"),
         r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),
@@ -49,6 +53,8 @@ rule polypolish_incomplete:
     if depth 5-25, run polypolish --careful
     if depth > 25, run polypolish default - might fix errors in repeats pypolca can't
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.incomp_pre_polish, "{sample}.fasta"),
         sam1=os.path.join(dir.out.bwa_incomplete, "{sample}_1.sam"),

--- a/hybracter/workflow/rules/polishing/short_read_polish_no_medaka.smk
+++ b/hybracter/workflow/rules/polishing/short_read_polish_no_medaka.smk
@@ -1,4 +1,6 @@
 rule bwa_index:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(
             dir.out.dnaapler,
@@ -25,6 +27,8 @@ rule bwa_index:
 
 
 rule bwa_mem:
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(
             dir.out.dnaapler,
@@ -65,6 +69,8 @@ rule polypolish:
     if depth 5-25, run polypolish --careful
     if depth > 25, run polypolish default - might fix errors in repeats pypolca can't
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(
             dir.out.dnaapler,
@@ -104,6 +110,8 @@ rule polypolish_extract_intermediate_assembly:
     """
     extracts the chromosome intermediate assembly
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.polypolish, "{sample}.fasta"),
         completeness_check=os.path.join(dir.out.completeness, "{sample}.txt"),
@@ -143,6 +151,8 @@ rule compare_assemblies_polypolish_vs_prechrom:
     """
     compare assemblies 
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         reference=os.path.join(
             dir.out.dnaapler, "{sample}", "{sample}_reoriented.fasta"

--- a/hybracter/workflow/rules/polishing/short_read_pypolca_no_medaka.smk
+++ b/hybracter/workflow/rules/polishing/short_read_pypolca_no_medaka.smk
@@ -4,6 +4,8 @@ rule pypolca:
     if coverage > 5, run pypolca --careful
     otherwise don't run pypolca at all (depth < 5) - copies file to make it work in snakemake for later
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         polypolish_fasta=os.path.join(dir.out.polypolish, "{sample}.fasta"),
         r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),
@@ -43,6 +45,8 @@ rule pypolca_extract_intermediate_assembly:
     """
     extracts the chromosome intermediate assembly from pypolca
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         fasta=os.path.join(dir.out.pypolca, "{sample}", "{sample}_corrected.fasta"),
         completeness_check=os.path.join(dir.out.completeness, "{sample}.txt"),
@@ -82,6 +86,8 @@ rule compare_assemblies_pypolca_vs_polypolish:
     """
     compare assemblies 
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         reference=os.path.join(
             dir.out.intermediate_assemblies, "{sample}", "{sample}_polypolish.fasta"
@@ -110,6 +116,8 @@ rule pypolca_incomplete:
     if coverage > 5, run pypolca --careful
     otherwise don't run pypolca at all (depth < 5) - copies file to make it work in snakemake for later
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         polypolish_fasta=os.path.join(dir.out.polypolish_incomplete, "{sample}.fasta"),
         r1=os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"),

--- a/hybracter/workflow/rules/preflight/targets_automatic.smk
+++ b/hybracter/workflow/rules/preflight/targets_automatic.smk
@@ -1,0 +1,39 @@
+"""
+All target output files are declared here
+"""
+
+# need long read polish aggr file regardless even if no polish selected
+# because of dnaapler
+"""
+polca depends on --no_pypolca flag
+"""
+
+# Pypolca
+if config.args.no_pypolca == True:
+    pypolca_files = []
+
+else:
+    pypolca_files = os.path.join(dir.out.flags, "aggr_pypolca.flag")
+
+
+"""
+automatic
+"""
+
+TargetFilesAutomatic = [
+    os.path.join(dir.out.flags, "aggr_long_qc.flag"),
+    os.path.join(dir.out.flags, "aggr_short_qc.flag"),
+    os.path.join(dir.out.flags, "aggr_lrge.flag"),
+    os.path.join(dir.out.flags, "aggr_seqkit_short.flag"),
+    os.path.join(dir.out.flags, "aggr_seqkit_long.flag"),
+    os.path.join(dir.out.flags, "aggr_assemble.flag"),
+    os.path.join(dir.out.flags, "aggr_short_read_polish.flag"),
+    os.path.join(dir.out.flags, "aggr_long_read_polish.flag"),
+    pypolca_files,
+    os.path.join(dir.out.flags, "aggr_ale.flag"),
+    os.path.join(dir.out.flags, "aggr_pyrodigal_plassembler.flag"),
+    os.path.join(dir.out.flags, "aggr_final.flag"),
+]
+
+# os.path.join(dir.out.flags, "aggr_plassembler.flag"),
+#     os.path.join(dir.out.flags, "aggr_combine_plassembler_info.flag"),

--- a/hybracter/workflow/rules/processing/coverage.smk
+++ b/hybracter/workflow/rules/processing/coverage.smk
@@ -50,8 +50,8 @@ rule aggr_seqkit_short:
     aggregates the seqkit stats over all samples
     """
     input:
-        expand(os.path.join(dir.out.seqkit, "{sample}_r1.txt"), sample=SAMPLES),
-        expand(os.path.join(dir.out.seqkit, "{sample}_r2.txt"), sample=SAMPLES),
+        expand(os.path.join(dir.out.seqkit, "{sample}_r1.txt"), sample=HYBRID_SAMPLES),
+        expand(os.path.join(dir.out.seqkit, "{sample}_r2.txt"), sample=HYBRID_SAMPLES),
     output:
         flag=os.path.join(dir.out.flags, "aggr_seqkit_short.flag"),
     resources:
@@ -133,6 +133,8 @@ rule estimate_sr_coverage:
     """
     quickly estimates short read coverage for pypolca and polypolish careful
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         r1=os.path.join(dir.out.seqkit, "{sample}_r1.txt"),
         r2=os.path.join(dir.out.seqkit, "{sample}_r2.txt"),

--- a/hybracter/workflow/rules/processing/qc.smk
+++ b/hybracter/workflow/rules/processing/qc.smk
@@ -79,6 +79,8 @@ rule fastp:
     """
     runs fastp on the paired end short reads
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         r1=get_input_r1,
         r2=get_input_r2,
@@ -138,8 +140,8 @@ rule aggr_short_qc:
     aggregates over all samples
     """
     input:
-        expand(os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"), sample=SAMPLES),
-        expand(os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"), sample=SAMPLES),
+        expand(os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"), sample=HYBRID_SAMPLES),
+        expand(os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"), sample=HYBRID_SAMPLES),
     output:
         flag=os.path.join(dir.out.flags, "aggr_short_qc.flag"),
     resources:

--- a/hybracter/workflow/rules/processing/remove_contaminants_qc.smk
+++ b/hybracter/workflow/rules/processing/remove_contaminants_qc.smk
@@ -231,8 +231,8 @@ rule aggr_short_qc:
     aggregates over all samples
     """
     input:
-        expand(os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"), sample=SAMPLES),
-        expand(os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"), sample=SAMPLES),
+        expand(os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"), sample=HYBRID_SAMPLES),
+        expand(os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"), sample=HYBRID_SAMPLES),
     output:
         flag=os.path.join(dir.out.flags, "aggr_short_qc.flag"),
     resources:

--- a/hybracter/workflow/rules/processing/skip_qc.smk
+++ b/hybracter/workflow/rules/processing/skip_qc.smk
@@ -33,6 +33,8 @@ rule skip_qc_short:
     copies short reads
     fastp detects gzip by default if file ends in .gz
     """
+    wildcard_constraints:
+        sample="|".join(HYBRID_SAMPLES)  # Only allow hybrid samples
     input:
         r1=get_input_r1,
         r2=get_input_r2,
@@ -75,8 +77,8 @@ rule aggr_short_skip_qc:
     aggregates over all samples short
     """
     input:
-        expand(os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"), sample=SAMPLES),
-        expand(os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"), sample=SAMPLES),
+        expand(os.path.join(dir.out.fastp, "{sample}_1.fastq.gz"), sample=HYBRID_SAMPLES),
+        expand(os.path.join(dir.out.fastp, "{sample}_2.fastq.gz"), sample=HYBRID_SAMPLES),
     output:
         flag=os.path.join(dir.out.flags, "aggr_short_qc.flag"),
     resources:


### PR DESCRIPTION
Hi George,

In my workflow, I sometimes have samples that have short read data available for them and sometimes there is only long read data available.
So every time I want to assemble them, I need to execute hybracter twice, instead of just letting it run over night in one go.

So I was wondering, why you separate the "hybrid" and "long-only" mode so strictly? Is this a deliberate design choice?

In this PR I wanted to present a **mockup (!!)** of how an "automatic" mode could work, which runs either the hybrid or the long-only pipeline, depending on the availability of short read paths in the sample.csv file (as seen in [hybracter/test_data/test_hybrid_automatic_auto.csv](https://github.com/gbouras13/hybracter/compare/main...richardstoeckl:hybracter:main?expand=1#diff-6f64aeea21fef258510baeaf10d0c9dec8c195f2ac9e609cb1ed8ac68386d8d4)), **on a per-sample basis.**

Basically, the idea is to add some logic to [hybracter/workflow/rules/preflight/samples.smk](https://github.com/gbouras13/hybracter/compare/main...richardstoeckl:hybracter:main?expand=1#diff-229ac8dd5ca73a09faba1502940fe5340194f760a07563a17ddc6d84c8678e31), so that the `SAMPLES` can be split into `HYBRID_SAMPLES` and `LONG_SAMPLES`, which can then be used in `wildcard_constraints` and in `expand()` functions to choose which samples get processed by either pipeline.


For this PR, I just did a very crude mockup, as I did not want to waste too much time if this Idea is not something you want to pursue further.
Please excuse the horrible python code in `samplesFromCsvAutomatic()`, `parseSamples()`, and `filter_samples_by_workflow_type()` and the copy-and-pasted-together rules and snaketool code, I tried my best to understand the inner workings.
The mockup works only with `hybracter automatic -i hybracter/test_data/test_hybrid_automatic_auto.csv --no_medaka --databases /path/to/databases/ --auto`, again, to not waste too much time. It "works" in the sense that it runs through on my machine without errors, but I have not checked for mistakes or on other machines.

If you want to pursue this idea further, let me know, and I can polish everything up a bit more.

Best wishes,
Richard